### PR TITLE
Add CommonMark cofigurations option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "mockery/mockery": "~0.9",
-        "phpunit/phpunit": "~5.4",
+        "phpunit/phpunit": "~4.0",
         "orchestra/testbench": "~3.2",
         "webuni/commonmark-attributes-extension": "0.3.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "league/commonmark": "0.10.*|0.12.*|0.13.*"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.4",
-        "phpunit/phpunit": "^4.7.6",
-        "orchestra/testbench": "~3.0",
+        "mockery/mockery": "~0.9",
+        "phpunit/phpunit": "~5.4",
+        "orchestra/testbench": "~3.2",
         "webuni/commonmark-attributes-extension": "0.3.*"
     },
     "autoload": {

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -34,7 +34,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Enable Markdown Extensions
+    | Include CommonMark Configuration
+    |--------------------------------------------------------------------------
+    |
+    | This option specifies the configuration options for the CommonMark
+    | converter. The following configuration will affect how CommonMark will
+    | parse your markdown.
+    |
+    | For more info on the possible configuration options:
+    | http://commonmark.thephpleague.com/configuration/
+    |
+    | Default: none
+    |
+    */
+
+    'configurations' => [
+        //
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Include CommonMark Extensions
     |--------------------------------------------------------------------------
     |
     | This option specifies the extensions to add to the CommonMark converter.

--- a/src/MarkdownServiceProvider.php
+++ b/src/MarkdownServiceProvider.php
@@ -57,6 +57,10 @@ class MarkdownServiceProvider extends ServiceProvider
             $config = $app['config']['markdown'];
             $environment = Environment::createCommonMarkEnvironment();
 
+            if ($config['configurations']) {
+                $environment->mergeConfig($config['configurations']);
+            }
+
             foreach ($config['extensions'] as $extension) {
                 if (class_exists($extension)) {
                     $environment->addExtension(new $extension());

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -80,4 +80,15 @@ class MarkdownTest extends MarkdownTestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    /**
+     * @test
+     */
+    public function it_can_compile_configured_markdown()
+    {
+        $actual = $this->app['view']->make('stubs::config')->render();
+        $expected = "<h1>*title*</h1>\n<h2>subtitle</h2>\n<p>text</p>\n";
+
+        $this->assertSame($expected, $actual);
+    }
 }

--- a/tests/MarkdownTestCase.php
+++ b/tests/MarkdownTestCase.php
@@ -6,17 +6,16 @@ use Orchestra\Testbench\TestCase;
 
 abstract class MarkdownTestCase extends TestCase
 {
-    protected function resolveApplicationConfiguration($app)
-    {
-        parent::resolveApplicationConfiguration($app);
-
-        $app['config']['markdown.extensions'] = [
-            \Webuni\CommonMark\AttributesExtension\AttributesExtension::class,
-        ];
-    }
-
     protected function getEnvironmentSetUp($app)
     {
+        $app['config']->set('markdown.configurations', [
+            'enable_em' => false,
+        ]);
+
+        $app['config']->set('markdown.extensions', [
+            \Webuni\CommonMark\AttributesExtension\AttributesExtension::class,
+        ]);
+
         $app['view']->addNamespace('stubs', realpath(__DIR__.'/stubs'));
     }
 

--- a/tests/stubs/config.md
+++ b/tests/stubs/config.md
@@ -1,0 +1,3 @@
+# *title*
+## subtitle
+text


### PR DESCRIPTION
This adds ability to overwrite CommonMark's default configurations with your own via the markdown configuration file.

Closes #2
